### PR TITLE
Fix restart issues

### DIFF
--- a/pkg/channel/data.go
+++ b/pkg/channel/data.go
@@ -24,12 +24,12 @@ type DataChan struct {
 	Data    *cloudevents.Event
 	Status  Status
 	//Type defines type of data (Notification,Metric,Status)
-	Type        Type
+	Type Type
 	// OnReceiveFn  to do on OnReceive
 	OnReceiveFn func(e cloudevents.Event)
 	// OnReceiveOverrideFn Optional for event, but override for status pings.This is an override function on receiving msg by amqp listener,
 	// if not set then the data is sent to out channel and processed by side car  default method
-	OnReceiveOverrideFn func(e cloudevents.Event,dataChan *DataChan) error
+	OnReceiveOverrideFn func(e cloudevents.Event, dataChan *DataChan) error
 	// ProcessEventFn  Optional, this allows to customize message handler thar was received at the out channel
 	ProcessEventFn func(e interface{}) error
 }

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -74,7 +74,6 @@ var (
 			Name: "cne_amqp_status_check_published",
 			Help: "Metric to get number of status check published by the transport",
 		}, []string{"address", "status"})
-
 )
 
 // RegisterMetrics ...
@@ -104,12 +103,11 @@ func UpdateEventCreatedCount(address string, status MetricStatus, val int) {
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
 
-// UpdateEventCreatedCount ...
+// UpdateStatusCheckCount ...
 func UpdateStatusCheckCount(address string, status MetricStatus, val int) {
 	amqpEventPublishedCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
-
 
 // UpdateSenderCreatedCount ...
 func UpdateSenderCreatedCount(address string, status MetricStatus, val int) {

--- a/pkg/protocol/amqp/amqp.go
+++ b/pkg/protocol/amqp/amqp.go
@@ -444,7 +444,7 @@ func (q *Router) SendTo(wg *sync.WaitGroup, address string, e *cloudevents.Event
 			return
 		}
 		wg.Add(1)
-		go func(q *Router, sender *Protocol,eventType channel.Type, address string, e *cloudevents.Event, wg *sync.WaitGroup) {
+		go func(q *Router, sender *Protocol, eventType channel.Type, address string, e *cloudevents.Event, wg *sync.WaitGroup) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(context.Background(), q.cancelTimeout)
 			defer cancel()
@@ -502,7 +502,7 @@ func (q *Router) SendTo(wg *sync.WaitGroup, address string, e *cloudevents.Event
 					Type:    eventType,
 				}
 			}
-		}(q, sender,eventType, address, e, wg)
+		}(q, sender, eventType, address, e, wg)
 	}
 }
 
@@ -512,27 +512,30 @@ func (q *Router) setReceiver(wg *sync.WaitGroup, d *channel.DataChan) error {
 		log.Errorf("error creating Receiver %v", err)
 		return err
 	}
-	d.OnReceiveFn = func(e cloudevents.Event) {
-		out := channel.DataChan{
-			Address:        d.Address,
-			Data:           &e,
-			Status:         channel.NEW,
-			Type:           channel.EVENT,
-			ProcessEventFn: d.ProcessEventFn,
-		}
-		if d.OnReceiveOverrideFn != nil {
-			if err := d.OnReceiveOverrideFn(e,&out); err != nil {
-				out.Status = channel.FAILED
-				localmetrics.UpdateEventReceivedCount(d.Address, localmetrics.FAILED, 1)
+	if d.OnReceiveFn == nil { // override only if OnReceiveFn is nil
+		d.OnReceiveFn = func(e cloudevents.Event) {
+			out := channel.DataChan{
+				Address:        d.Address,
+				Data:           &e,
+				Status:         channel.NEW,
+				Type:           channel.EVENT,
+				ProcessEventFn: d.ProcessEventFn,
+			}
+			if d.OnReceiveOverrideFn != nil {
+				if err := d.OnReceiveOverrideFn(e, &out); err != nil {
+					out.Status = channel.FAILED
+					localmetrics.UpdateEventReceivedCount(d.Address, localmetrics.FAILED, 1)
+				} else {
+					localmetrics.UpdateEventReceivedCount(d.Address, localmetrics.SUCCESS, 1)
+					out.Status = channel.SUCCESS
+				}
 			} else {
 				localmetrics.UpdateEventReceivedCount(d.Address, localmetrics.SUCCESS, 1)
-				out.Status = channel.SUCCESS
 			}
-		} else {
-			localmetrics.UpdateEventReceivedCount(d.Address, localmetrics.SUCCESS, 1)
+			q.DataOut <- &out
 		}
-		q.DataOut <- &out
 	}
+
 	wg.Add(1)
 	go q.Receive(wg, d.Address, d.OnReceiveFn)
 	log.Infof("done setting up receiver for consumer")

--- a/pkg/protocol/amqp/amqp_test.go
+++ b/pkg/protocol/amqp/amqp_test.go
@@ -158,7 +158,7 @@ func TestDeleteListener(t *testing.T) {
 		Type:                channel.LISTENER,
 		Status:              channel.NEW,
 		ProcessEventFn:      func(e interface{}) error { return nil },
-		OnReceiveOverrideFn: func(e cloudevents.Event,dataChan *channel.DataChan) error { return nil },
+		OnReceiveOverrideFn: func(e cloudevents.Event, dataChan *channel.DataChan) error { return nil },
 	}
 	time.Sleep(250 * time.Millisecond)
 	assert.Equal(t, 1, len(server.Listeners))
@@ -199,7 +199,7 @@ func TestSendSuccessStatus(t *testing.T) {
 		Status:              channel.NEW,
 		Type:                channel.LISTENER,
 		ProcessEventFn:      func(e interface{}) error { return nil },
-		OnReceiveOverrideFn: func(e cloudevents.Event,dataChan *channel.DataChan) error { return nil },
+		OnReceiveOverrideFn: func(e cloudevents.Event, dataChan *channel.DataChan) error { return nil },
 	}
 
 	// create a sender
@@ -242,11 +242,13 @@ func TestSendFailureStatus(t *testing.T) {
 	// always you need to define how you handle status  when it is received
 	// do not override for events
 	in <- &channel.DataChan{
-		Address:             fmt.Sprintf("%s/%s", addr, "status"),
-		Status:              channel.NEW,
-		Type:                channel.LISTENER,
-		ProcessEventFn:      func(e interface{}) error { return fmt.Errorf("EVENT PROCESS ERROR") },
-		OnReceiveOverrideFn: func(e cloudevents.Event,dataChan *channel.DataChan) error { return fmt.Errorf("STATUS RECEEIVE ERROR") },
+		Address:        fmt.Sprintf("%s/%s", addr, "status"),
+		Status:         channel.NEW,
+		Type:           channel.LISTENER,
+		ProcessEventFn: func(e interface{}) error { return fmt.Errorf("EVENT PROCESS ERROR") },
+		OnReceiveOverrideFn: func(e cloudevents.Event, dataChan *channel.DataChan) error {
+			return fmt.Errorf("STATUS RECEEIVE ERROR")
+		},
 	}
 
 	// create a sender
@@ -319,7 +321,7 @@ func TestSendEvent(t *testing.T) {
 		Status:              channel.NEW,
 		Type:                channel.LISTENER,
 		ProcessEventFn:      func(e interface{}) error { return nil },
-		OnReceiveOverrideFn: func(e cloudevents.Event,dataChan *channel.DataChan) error { return nil },
+		OnReceiveOverrideFn: func(e cloudevents.Event, dataChan *channel.DataChan) error { return nil },
 	}
 
 	// create a sender

--- a/v1/amqp/amqp.go
+++ b/v1/amqp/amqp.go
@@ -114,7 +114,7 @@ func CreateListener(inChan chan<- *channel.DataChan, address string) {
 
 //CreateNewStatusListener send status address information  on a channel to create it's listener object
 func CreateNewStatusListener(inChan chan<- *channel.DataChan, address string,
-	onReceiveOverrideFn func(e cloudevents.Event,dataChan *channel.DataChan) error,
+	onReceiveOverrideFn func(e cloudevents.Event, dataChan *channel.DataChan) error,
 	processEventFn func(e interface{}) error) {
 	// go ahead and create QDR listener to this address
 	inChan <- &channel.DataChan{


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
during  amq connection failures and reconnection attempt.
The amq object  loses onReceive overriding function.
This PR check first to see if the on-receive is empty only then attaches override Function.
By doing this , it retains the func call when recreated. This is special case for Status Check