### PR TITLE
Fix OriginOfCondition encoding in EventRecord

### DIFF
--- a/pkg/hwevent/event.go
+++ b/pkg/hwevent/event.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Event represents the canonical representation of a Hardware Event.
-// Event Json  payload is as follows,
+// Example payload:
 //{
 //  "id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
 //  "type": "event.synchronization-state-chang",
@@ -43,7 +43,7 @@ import (
 // 		      "Cached"
 // 		    ],
 // 		    "MessageId": "iLOEvents.2.1.ServerPoweredOff",
-// 		    "OriginOfCondition": "/redfish/v1/Systems/1/",
+// 		    "OriginOfCondition": {"@odata.id":"/redfish/v1/Systems/System.Embedded.1"},
 // 		    "Severity": "OK"
 // 	      }
 // 	    ],

--- a/pkg/hwevent/event_ce_test.go
+++ b/pkg/hwevent/event_ce_test.go
@@ -38,17 +38,17 @@ var (
 	pubsub cnepubsub.PubSub
 
 	EVENT_RECORD_TMP0100 = hwevent.EventRecord{
-		Context:        "any string is valid",
-		EventID:        "2162",
-		EventTimestamp: "2021-07-13T15:07:59+0300",
-		EventType:      "Alert",
-		MemberID:       "615703",
-		Message:        "The system board Inlet temperature is less than the lower warning threshold.",
-		MessageArgs:    []string{"Inlet"},
-		MessageID:      "TMP0100",
-		Severity:       "Warning",
+		Context:           "any string is valid",
+		EventID:           "2162",
+		EventTimestamp:    "2021-07-13T15:07:59+0300",
+		EventType:         "Alert",
+		MemberID:          "615703",
+		Message:           "The system board Inlet temperature is less than the lower warning threshold.",
+		MessageArgs:       []string{"Inlet"},
+		MessageID:         "TMP0100",
+		OriginOfCondition: []byte(`{"@odata.id":"/redfish/v1/Systems/System.Embedded.1"}`),
+		Severity:          "Warning",
 	}
-
 	REDFISH_EVENT_TMP0100 = hwevent.RedfishEvent{
 		OdataContext: "/redfish/v1/$metadata#Event.Event",
 		OdataType:    "#Event.v1_3_0.Event",
@@ -157,7 +157,7 @@ func assertCEJsonEquals(t *testing.T, want *ce.Event, got []byte) {
 	var gotToCompare map[string]interface{}
 	require.NoError(t, json.Unmarshal(got, &gotToCompare))
 
-	// Marshal and unmarshal want to make sure the types are correct
+	// Marshal and unmarshal `want` to make sure the types are correct
 	wantBytes, err := json.Marshal(want)
 	require.NoError(t, err)
 	var wantToCompare map[string]interface{}
@@ -170,7 +170,7 @@ func assertCNEJsonEquals(t *testing.T, want *hwevent.Event, got []byte) {
 	var gotToCompare map[string]interface{}
 	require.NoError(t, json.Unmarshal(got, &gotToCompare))
 
-	// Marshal and unmarshal want to make sure the types are correct
+	// Marshal and unmarshal `want` to make sure the types are correct
 	wantBytes, err := json.Marshal(want)
 	require.NoError(t, err)
 	var wantToCompare map[string]interface{}

--- a/pkg/hwevent/event_data.go
+++ b/pkg/hwevent/event_data.go
@@ -75,7 +75,7 @@ type EventRecord struct {
 	// This indicates the resource that originated the condition that
 	// caused the event to be generated.
 	// +optional
-	OriginOfCondition string `json:"OriginOfCondition,omitempty"`
+	OriginOfCondition []byte `json:"OriginOfCondition,omitempty"`
 	//  This is the severity of the event.
 	// +optional
 	Severity string `json:"Severity,omitempty"`
@@ -120,8 +120,8 @@ func (e EventRecord) String() string {
 	if e.Oem != nil {
 		b.WriteString("      Oem: " + string(e.Oem) + "\n")
 	}
-	if e.OriginOfCondition != "" {
-		b.WriteString("      OriginOfCondition: " + e.OriginOfCondition + "\n")
+	if e.OriginOfCondition != nil {
+		b.WriteString("      OriginOfCondition: " + string(e.OriginOfCondition) + "\n")
 	}
 	if e.Severity != "" {
 		b.WriteString("      Severity: " + e.Severity + "\n")

--- a/pkg/hwevent/event_marshal.go
+++ b/pkg/hwevent/event_marshal.go
@@ -79,12 +79,7 @@ func WriteJSON(in *Event, writer io.Writer) error {
 	stream.WriteObjectEnd()
 	// Let's do a check on the error
 	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event Data: %w", stream.Error)
-	}
-
-	// Let's do a check on the error
-	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event extensions: %w", stream.Error)
+		return fmt.Errorf("error while writing the Event data: %w", stream.Error)
 	}
 	return stream.Flush()
 }
@@ -119,13 +114,9 @@ func writeJSONData(in *Data, writer io.Writer, stream *jsoniter.Stream) error {
 
 	// Let's do a check on the error
 	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event Data: %w", stream.Error)
+		return fmt.Errorf("error while writing the Data data: %w", stream.Error)
 	}
 
-	// Let's do a check on the error
-	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event extensions: %w", stream.Error)
-	}
 	return nil
 }
 
@@ -207,12 +198,7 @@ func writeJSONRedfishEvent(in *RedfishEvent, writer io.Writer, stream *jsoniter.
 
 	// Let's do a check on the error
 	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event Data: %w", stream.Error)
-	}
-
-	// Let's do a check on the error
-	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event extensions: %w", stream.Error)
+		return fmt.Errorf("error while writing the RedfishEvent data: %w", stream.Error)
 	}
 	return nil
 }
@@ -228,7 +214,7 @@ func writeJSONEventRecord(in *EventRecord, writer io.Writer, stream *jsoniter.St
 			stream.WriteObjectField("Actions")
 			_, err = stream.Write(data.Actions)
 			if err != nil {
-				return fmt.Errorf("error writing Oem: %w", err)
+				return fmt.Errorf("error writing Actions: %w", err)
 			}
 			stream.WriteMore()
 		}
@@ -277,9 +263,12 @@ func writeJSONEventRecord(in *EventRecord, writer io.Writer, stream *jsoniter.St
 			}
 			stream.WriteMore()
 		}
-		if data.OriginOfCondition != "" {
+		if data.OriginOfCondition != nil {
 			stream.WriteObjectField("OriginOfCondition")
-			stream.WriteString(data.OriginOfCondition)
+			_, err = stream.Write(data.OriginOfCondition)
+			if err != nil {
+				return fmt.Errorf("error writing OriginOfCondition: %w", err)
+			}
 			stream.WriteMore()
 		}
 		if data.Severity != "" {
@@ -320,12 +309,7 @@ func writeJSONEventRecord(in *EventRecord, writer io.Writer, stream *jsoniter.St
 
 	// Let's do a check on the error
 	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event Data: %w", stream.Error)
-	}
-
-	// Let's do a check on the error
-	if stream.Error != nil {
-		return fmt.Errorf("error while writing the event extensions: %w", stream.Error)
+		return fmt.Errorf("error while writing the EventRecord data: %w", stream.Error)
 	}
 	return nil
 }

--- a/pkg/hwevent/event_marshal_test.go
+++ b/pkg/hwevent/event_marshal_test.go
@@ -43,7 +43,11 @@ var (
 				"MessageArgs":             []string{"Inlet"},
 				"MessageArgs@odata.count": 1,
 				"MessageId":               "TMP0100",
-				"Severity":                "Warning",
+				// Do not use []byte here since json.Marshal from standard library will encode []byte with base64
+				"OriginOfCondition": map[string]interface{}{
+					"@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+				},
+				"Severity": "Warning",
 			},
 		},
 		"Id":   "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
@@ -103,18 +107,12 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func mustJSONMarshal(tb testing.TB, body interface{}) []byte {
-	b, err := json.Marshal(body)
-	require.NoError(tb, err)
-	return b
-}
-
 func assertJSONEquals(t *testing.T, want map[string]interface{}, got []byte) {
-	//var gotToCompare map[string]interface{}
 	gotToCompare := hwevent.Event{}
 	require.NoError(t, json.Unmarshal(got, &gotToCompare))
 
-	// Marshal and unmarshal want to make sure the types are correct
+	// Marshal and unmarshal `want` to make sure the types are correct
+	// NOTE: json.Marshal from the standard `encoding/json` library is used here
 	wantBytes, err := json.Marshal(want)
 	require.NoError(t, err)
 	wantToCompare := hwevent.Event{}

--- a/pkg/hwevent/event_unmarshal_test.go
+++ b/pkg/hwevent/event_unmarshal_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/redhat-cne/sdk-go/pkg/hwevent"
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhat-cne/sdk-go/pkg/types"
@@ -66,4 +67,10 @@ func TestUnMarshal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustJSONMarshal(tb testing.TB, body interface{}) []byte {
+	b, err := json.Marshal(body)
+	require.NoError(tb, err)
+	return b
 }


### PR DESCRIPTION
Changed OriginOfCondition from String type to Object type according to the Redfish schema.

Added missing UnmarshalJSON function for RedfishEvent.

Signed-off-by: Jack Ding <jacding@redhat.com>