### PR TITLE
Bug 2033404: Add source in event

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -28,30 +28,20 @@ import (
 //{
 //	"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
 //	"type": "event.sync.sync-status.synchronization-state-change",
+//	"source": "/cluster/node/example.com/ptp/clock_realtime",
 //	"time": "2021-02-05T17:31:00Z",
 //	"data": {
 //		"version": "v1.0",
 //		"values": [{
-//			"resource": "/cluster/node/ptp",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "notification",
 //			"valueType": "enumeration",
 //			"value": "ACQUIRING-SYNC"
 //			}, {
-//			"resource": "/cluster/node/clock",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "metric",
 //			"valueType": "decimal64.3",
 //			"value": 100.3
-//			}, {
-//			"resource": "/cluster/node/temp",
-//			"dataType": "notification",
-//			"valueType": "redfish-event",
-//			"value": {
-//			"@odata.context": "/redfish/v1/$metadata#Event.Event",
-//			"@odata.type": "#Event.v1_3_0.Event",
-//			"Context": "any string is valid",
-//			"Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
-//			"Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
-//			"Name": "Event Array"
 //			}]
 //		}
 //}
@@ -63,6 +53,9 @@ type Event struct {
 	// Type - The type of the occurrence which has happened.
 	// +required
 	Type string `json:"type" example:"event.sync.sync-status.synchronization-state-change"`
+	// Source - The source of the occurrence which has happened.
+	// +required
+	Source string `json:"source" example:"/cluster/node/example.com/ptp/clock_realtime"`
 	// DataContentType - the Data content type
 	// +required
 	DataContentType *string `json:"dataContentType" example:"application/json"`

--- a/pkg/event/event_ce.go
+++ b/pkg/event/event_ce.go
@@ -50,6 +50,7 @@ func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	e.SetDataContentType(ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }

--- a/pkg/event/event_ce_test.go
+++ b/pkg/event/event_ce_test.go
@@ -38,6 +38,7 @@ var (
 	endPointURI = "http://localhost:8080/event/ack/event"
 	resource    = "/cluster/node/ptp"
 	_type       = string(ptp.PtpStateChange)
+	_source     = "/cluster/node/example.com/ptp/clock_realtime"
 	version     = "v1"
 	id          = uuid.New().String()
 	data        cneevent.Data
@@ -73,10 +74,10 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 		"struct Data v1": {
 			cneEvent: func() *cneevent.Event {
 				e := cneeventv1.CloudNativeEvent()
-
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
+				e.SetSource(_source)
 				e.SetData(data)
 				return &e
 			}(),
@@ -131,6 +132,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
+				e.SetSource(pubsub.GetResource())
 				e.SetData(data)
 				return &e
 			}(),

--- a/pkg/event/event_data.go
+++ b/pkg/event/event_data.go
@@ -46,17 +46,17 @@ const (
 //{
 //	"version": "v1.0",
 //	"values": [{
-//		"resource": "/cluster/node/ptp",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "notification",
 //		"valueType": "enumeration",
 //		"value": "ACQUIRING-SYNC"
 //		}, {
-//		"resource": "/cluster/node/clock",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "metric",
 //		"valueType": "decimal64.3",
 //		"value": 100.3
 //		}, {
-//		"resource": "/cluster/node/temp",
+//		"resource": "/redfish/v1/Systems",
 //		"dataType": "notification",
 //		"valueType": "redfish-event",
 //		"value": {

--- a/pkg/event/event_marshal.go
+++ b/pkg/event/event_marshal.go
@@ -39,6 +39,10 @@ func WriteJSON(in *Event, writer io.Writer) error {
 
 			stream.WriteObjectField("type")
 			stream.WriteString(in.GetType())
+			stream.WriteMore()
+
+			stream.WriteObjectField("source")
+			stream.WriteString(in.GetSource())
 
 			if in.GetDataContentType() != "" {
 				stream.WriteMore()

--- a/pkg/event/event_marshal_test.go
+++ b/pkg/event/event_marshal_test.go
@@ -33,6 +33,7 @@ func TestMarshal(t *testing.T) {
 	schemaURL := "http://example.com/schema"
 	resource := "/cluster/node/ptp"
 	_type := string(ptp.PtpStateChange)
+	_source := "/cluster/node/example.com/ptp/clock_realtime"
 	version := "v1"
 	data := event.Data{}
 	value := []event.DataValue{{
@@ -69,6 +70,7 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetDataSchema(schemaURL)
 				e.Time = &now
 				e.SetType(_type)
+				e.SetSource(_source)
 				e.SetData(data)
 
 				return e
@@ -92,6 +94,7 @@ func TestMarshal(t *testing.T) {
 				"id":         "",
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       _type,
+				"source":     _source,
 				"dataSchema": schemaURL,
 			},
 		},

--- a/pkg/event/event_reader.go
+++ b/pkg/event/event_reader.go
@@ -25,6 +25,11 @@ func (e *Event) GetType() string {
 	return e.Type
 }
 
+// GetSource implements Reader.Source
+func (e *Event) GetSource() string {
+	return e.Source
+}
+
 // GetID implements Reader.ID
 func (e *Event) GetID() string {
 	return e.ID

--- a/pkg/event/event_unmarshal.go
+++ b/pkg/event/event_unmarshal.go
@@ -85,11 +85,12 @@ func readDataJSONFromIterator(out *Data, iterator *jsoniter.Iterator) error {
 func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	var (
 		// Universally parseable fields.
-		id   string
-		typ  string
-		time *types.Timestamp
-		data *Data
-		err  error
+		id     string
+		typ    string
+		source string
+		time   *types.Timestamp
+		data   *Data
+		err    error
 
 		// These fields require knowledge about the specversion to be parsed.
 		//schemaurl jsoniter.Any
@@ -107,6 +108,8 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 			id = iterator.ReadString()
 		case "type":
 			typ = iterator.ReadString()
+		case "source":
+			source = iterator.ReadString()
 		case "time":
 			time = readTimestamp(iterator)
 		case "data":
@@ -130,6 +133,7 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	out.Time = time
 	out.ID = id
 	out.Type = typ
+	out.Source = source
 	if data != nil {
 		out.SetData(*data)
 	}

--- a/pkg/event/event_unmarshal_test.go
+++ b/pkg/event/event_unmarshal_test.go
@@ -16,6 +16,7 @@ func TestUnMarshal(t *testing.T) {
 	now := types.Timestamp{Time: time.Now().UTC()}
 	resource := "/cluster/node/ptp"
 	_type := string(ptp.PtpStateChange)
+	_source := "/cluster/node/example.com/ptp/clock_realtime"
 	version := "v1"
 	id := "ABC-1234"
 
@@ -45,11 +46,13 @@ func TestUnMarshal(t *testing.T) {
 				"id":         id,
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       _type,
+				"source":     _source,
 				"dataSchema": nil,
 			}),
 			want: &event.Event{
 				ID:         id,
 				Type:       _type,
+				Source:     _source,
 				Time:       &now,
 				DataSchema: nil,
 				Data: &event.Data{
@@ -91,11 +94,13 @@ func TestUnMarshal(t *testing.T) {
 				"id":         id,
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       _type,
+				"source":     _source,
 				"dataSchema": nil,
 			}),
 			want: &event.Event{
 				ID:         id,
 				Type:       _type,
+				Source:     _source,
 				Time:       &now,
 				DataSchema: nil,
 				Data: &event.Data{
@@ -134,6 +139,7 @@ func TestUnMarshal(t *testing.T) {
 				"id":         id,
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       _type,
+				"source":     _source,
 				"dataSchema": nil,
 			}),
 			wantErr: fmt.Errorf("value type foo is not supported"),

--- a/pkg/event/event_writer.go
+++ b/pkg/event/event_writer.go
@@ -29,6 +29,11 @@ func (e *Event) SetType(t string) {
 	e.Type = t
 }
 
+// SetSource implements Writer.SetSource
+func (e *Event) SetSource(s string) {
+	e.Source = s
+}
+
 // SetID implements Writer.SetID
 func (e *Event) SetID(id string) {
 	e.ID = id

--- a/pkg/event/ptp/resource.go
+++ b/pkg/event/ptp/resource.go
@@ -14,31 +14,31 @@
 
 package ptp
 
-// EventSource ...
-type EventSource string
+// EventResource ...
+type EventResource string
 
 const (
 	// GnssSyncStatus notification is signalled from equipment at state change
-	GnssSyncStatus EventSource = "/sync/gnss-status/gnss-sync-status"
+	GnssSyncStatus EventResource = "/sync/gnss-status/gnss-sync-status"
 
 	// OsClockSyncState State of node OS clock synchronization is notified at state change
-	OsClockSyncState EventSource = "/sync/sync-status/os-clock-sync-state"
+	OsClockSyncState EventResource = "/sync/sync-status/os-clock-sync-state"
 
 	// PtpClockClass notification is generated when the clock-class changes.
-	PtpClockClass EventSource = "/sync/ptp-status/ptp-clock-class-change"
+	PtpClockClass EventResource = "/sync/ptp-status/ptp-clock-class-change"
 
 	// PtpLockState notification is signalled from equipment at state change
-	PtpLockState EventSource = "/sync/ptp-status/lock-state"
+	PtpLockState EventResource = "/sync/ptp-status/lock-state"
 
 	// SynceClockQuality notification is generated when the clock-quality changes.
-	SynceClockQuality EventSource = "/sync/synce-status/clock-quality"
+	SynceClockQuality EventResource = "/sync/synce-status/clock-quality"
 
 	// SynceLockState Notification used to inform about synce synchronization state change
-	SynceLockState EventSource = "/sync/synce-status/lock-state"
+	SynceLockState EventResource = "/sync/synce-status/lock-state"
 
 	// SynceLockStateExtended notification is signalled from equipment at state change, enhanced information
-	SynceLockStateExtended EventSource = "/sync/synce-status/lock-state-extended"
+	SynceLockStateExtended EventResource = "/sync/synce-status/lock-state-extended"
 
 	// SyncStatusState State of equipment synchronization is notified at state change
-	SyncStatusState EventSource = "/sync/sync-status/sync-state"
+	SyncStatusState EventResource = "/sync/sync-status/sync-state"
 )

--- a/pkg/event/redfish/event_ce_test.go
+++ b/pkg/event/redfish/event_ce_test.go
@@ -98,6 +98,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
+				e.SetSource(pubsub.GetResource())
 				e.SetData(data)
 				return &e
 			}(),
@@ -152,6 +153,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
+				e.SetSource(pubsub.GetResource())
 				e.SetData(data)
 				return &e
 			}(),

--- a/pkg/event/redfish/event_marshal_test.go
+++ b/pkg/event/redfish/event_marshal_test.go
@@ -58,6 +58,7 @@ func TestMarshal(t *testing.T) {
 	now := types.Timestamp{Time: time.Now().UTC()}
 	schemaURL := "http://example.com/schema"
 	_type := string(redfish.Alert)
+	_source := "/cluster/node/nodename/redfish/event"
 	version := "v1"
 	data := event.Data{}
 	value := event.DataValue{
@@ -81,6 +82,7 @@ func TestMarshal(t *testing.T) {
 				_ = e.SetDataSchema(schemaURL)
 				e.Time = &now
 				e.SetType(_type)
+				e.SetSource(_source)
 				e.SetData(data)
 				return e
 			}(),
@@ -101,6 +103,7 @@ func TestMarshal(t *testing.T) {
 				"id":         "",
 				"time":       now.Format(time.RFC3339Nano),
 				"type":       _type,
+				"source":     _source,
 				"dataSchema": schemaURL,
 			},
 		},

--- a/pkg/event/redfish/resource.go
+++ b/pkg/event/redfish/resource.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+// EventResource ...
+type EventResource string
+
+const (
+	// Systems is odata.id of the generic origin of redfish events
+	Systems EventResource = "/redfish/v1/Systems"
+)

--- a/v1/event/event.go
+++ b/v1/event/event.go
@@ -110,6 +110,7 @@ func GetCloudNativeEvents(ce cloudevents.Event) (e event.Event, err error) {
 	e.SetDataContentType(event.ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }


### PR DESCRIPTION
- Add `source` as a required attribute in event.
- Update the `resource` under `event.data.values` to be resource type instead of the source.

Signed-off-by: Jack Ding <jacding@redhat.com>