### PR TITLE
Event source was lost when converting cloud native events to events.

### DIFF
--- a/pkg/event/event_ce.go
+++ b/pkg/event/event_ce.go
@@ -29,6 +29,7 @@ func (e *Event) NewCloudEvent(ps *pubsub.PubSub) (*cloudevent.Event, error) {
 	ce.SetTime(e.GetTime())
 	ce.SetType(e.Type)
 	ce.SetDataContentType(cloudevent.ApplicationJSON)
+	ce.SetSubject(e.Source)   // subject is set to source of the event object
 	ce.SetSource(ps.Resource) // bus address
 	ce.SetSpecVersion(cloudevent.VersionV03)
 	ce.SetID(uuid.New().String())
@@ -50,7 +51,9 @@ func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	e.SetDataContentType(ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
-	e.SetSource(ce.Source())
+	e.SetSource(ce.Subject())
 	e.SetData(data)
+	e.SetID(ce.ID())
+
 	return
 }

--- a/pkg/event/event_ce_test.go
+++ b/pkg/event/event_ce_test.go
@@ -79,6 +79,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				e.SetType(_type)
 				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 			cnePubsub: &pubsub,
@@ -89,6 +90,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -124,6 +126,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -132,8 +135,9 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 		},

--- a/pkg/event/redfish/event_ce_test.go
+++ b/pkg/event/redfish/event_ce_test.go
@@ -37,6 +37,7 @@ var (
 	uriLocation = "http://localhost:8089/api/cloudNotifications/v1/subscriptions/da42fb86-819e-47c5-84a3-5512d5a3c732"
 	endPointURI = "http://localhost:9089/event"
 	resource    = "/cluster/node/nodename/redfish/event"
+	_source     = "/cluster/node/nodename/redfish/event/fan"
 	_type       = string(redfish.Alert)
 	version     = "v1"
 	id          = uuid.New().String()
@@ -98,8 +99,9 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 			cnePubsub: &pubsub,
@@ -110,6 +112,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -145,6 +148,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -153,8 +157,9 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 		},

--- a/v1/event/event.go
+++ b/v1/event/event.go
@@ -111,6 +111,7 @@ func GetCloudNativeEvents(ce cloudevents.Event) (e event.Event, err error) {
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
 	e.SetSource(ce.Source())
+	e.SetID(ce.ID())
 	e.SetData(data)
 	return
 }


### PR DESCRIPTION
This is  fixed by copy native events source to cloud events subject
bus address is set to the source of cloud events.
When unpacking from cloud events to cloud-native events, the process needs to copy the subject back to cloud events
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>