### PR TITLE
Event source swap with subject when converting from one schema to another

### DIFF
--- a/pkg/event/event_ce.go
+++ b/pkg/event/event_ce.go
@@ -29,6 +29,7 @@ func (e *Event) NewCloudEvent(ps *pubsub.PubSub) (*cloudevent.Event, error) {
 	ce.SetTime(e.GetTime())
 	ce.SetType(e.Type)
 	ce.SetDataContentType(cloudevent.ApplicationJSON)
+	ce.SetSubject(e.Source)   // subject is set to source of the event object
 	ce.SetSource(ps.Resource) // bus address
 	ce.SetSpecVersion(cloudevent.VersionV03)
 	ce.SetID(uuid.New().String())
@@ -50,7 +51,13 @@ func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	e.SetDataContentType(ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
-	e.SetSource(ce.Source())
+	if ce.Subject() != "" {
+		e.SetSource(ce.Subject())
+	} else {
+		e.SetSource(ce.Source())
+	}
 	e.SetData(data)
+	e.SetID(ce.ID())
+
 	return
 }

--- a/pkg/event/event_ce_test.go
+++ b/pkg/event/event_ce_test.go
@@ -79,6 +79,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				e.SetType(_type)
 				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 			cnePubsub: &pubsub,
@@ -89,6 +90,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -124,6 +126,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -132,8 +135,9 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 		},

--- a/pkg/event/redfish/event_ce_test.go
+++ b/pkg/event/redfish/event_ce_test.go
@@ -37,6 +37,7 @@ var (
 	uriLocation = "http://localhost:8089/api/cloudNotifications/v1/subscriptions/da42fb86-819e-47c5-84a3-5512d5a3c732"
 	endPointURI = "http://localhost:9089/event"
 	resource    = "/cluster/node/nodename/redfish/event"
+	_source     = "/cluster/node/nodename/redfish/event/fan"
 	_type       = string(redfish.Alert)
 	version     = "v1"
 	id          = uuid.New().String()
@@ -98,8 +99,9 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 			cnePubsub: &pubsub,
@@ -110,6 +112,7 @@ func TestEvent_NewCloudEvent(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -145,6 +148,7 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				_ = e.SetData(ce.ApplicationJSON, data)
 				e.SetTime(now.Time)
 				e.SetSource(pubsub.GetResource())
+				e.SetSubject(_source)
 				e.SetID(id)
 				return &e
 			}(),
@@ -153,8 +157,9 @@ func TestEvent_GetCloudNativeEvents(t *testing.T) {
 				e.SetDataContentType(cneevent.ApplicationJSON)
 				e.SetTime(now.Time)
 				e.SetType(_type)
-				e.SetSource(pubsub.GetResource())
+				e.SetSource(_source)
 				e.SetData(data)
+				e.SetID(id)
 				return &e
 			}(),
 		},

--- a/v1/event/event.go
+++ b/v1/event/event.go
@@ -89,6 +89,7 @@ func CreateCloudEvents(e event.Event, ps pubsub.PubSub) (*cloudevents.Event, err
 	ce.SetTime(e.GetTime())
 	ce.SetType(e.Type)
 	ce.SetDataContentType(cloudevents.ApplicationJSON)
+	ce.SetSubject(e.Source)   // subject is set to source of the event object
 	ce.SetSource(ps.Resource) // bus address
 	ce.SetSpecVersion(cloudevents.VersionV03)
 	ce.SetID(uuid.New().String())
@@ -110,7 +111,13 @@ func GetCloudNativeEvents(ce cloudevents.Event) (e event.Event, err error) {
 	e.SetDataContentType(event.ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
-	e.SetSource(ce.Source())
+	if ce.Subject() != "" {
+		e.SetSource(ce.Subject())
+	} else {
+		e.SetSource(ce.Source())
+	}
+	e.SetSource(ce.Subject())
+	e.SetID(ce.ID())
 	e.SetData(data)
 	return
 }


### PR DESCRIPTION
Fixe to add a source to the subject of the cloud events and read it back on converting it to cloud-native events