### PR TITLE
Fix http restart from persistent store

### DIFF
--- a/pkg/channel/doc.go
+++ b/pkg/channel/doc.go
@@ -1,2 +1,2 @@
-//Package channel  provides various channel types used for event.
+// Package channel  provides various channel types used for event.
 package channel

--- a/pkg/channel/pipeline.go
+++ b/pkg/channel/pipeline.go
@@ -26,7 +26,7 @@ var (
 	channelBufferSize = 10
 )
 
-//NewStatusListenerChannel ...
+// NewStatusListenerChannel ...
 func NewStatusListenerChannel(wg *sync.WaitGroup) *ListenerChannel {
 	listener := &ListenerChannel{
 		listener: make(chan RestAPIChannel, channelBufferSize),
@@ -38,7 +38,7 @@ func NewStatusListenerChannel(wg *sync.WaitGroup) *ListenerChannel {
 	return listener
 }
 
-//NewStatusRestAPIChannel ...
+// NewStatusRestAPIChannel ...
 func NewStatusRestAPIChannel(seqID int, dataCh chan<- cloudevents.Event) RestAPIChannel {
 	return RestAPIChannel{
 		sequenceID: seqID,
@@ -46,27 +46,27 @@ func NewStatusRestAPIChannel(seqID int, dataCh chan<- cloudevents.Event) RestAPI
 	}
 }
 
-//RestAPIChannel ...
+// RestAPIChannel ...
 type RestAPIChannel struct {
 	sequenceID int
 	dataCh     chan<- cloudevents.Event
 }
 
-//ListenerChannel ...
+// ListenerChannel ...
 type ListenerChannel struct {
 	listener chan RestAPIChannel
 	store    map[int]chan<- cloudevents.Event
 	done     chan bool
 }
 
-//Done ...
+// Done ...
 func (s *ListenerChannel) Done() {
 	s.done <- true
 }
 
-//Listen ...
+// Listen ...
 // put in the map; so the you receiver will read the map and sequence id is found then
-//send to channel found in the map
+// send to channel found in the map
 func (s *ListenerChannel) Listen(wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer func() {
@@ -84,9 +84,9 @@ func (s *ListenerChannel) Listen(wg *sync.WaitGroup) {
 	}
 }
 
-//SendToCaller ...
-//TODO:Clean up store on errors
-//SendToCaller ...
+// SendToCaller ...
+// TODO:Clean up store on errors
+// SendToCaller ...
 func (s *ListenerChannel) SendToCaller(sequenceID int, dataCh cloudevents.Event) {
 	if d, ok := s.store[sequenceID]; ok {
 		d <- dataCh
@@ -96,7 +96,7 @@ func (s *ListenerChannel) SendToCaller(sequenceID int, dataCh cloudevents.Event)
 	}
 }
 
-//GetChannel ...
+// GetChannel ...
 func (s *ListenerChannel) GetChannel(sequenceID int) chan<- cloudevents.Event {
 	if d, ok := s.store[sequenceID]; ok {
 		return d
@@ -104,12 +104,12 @@ func (s *ListenerChannel) GetChannel(sequenceID int) chan<- cloudevents.Event {
 	return nil
 }
 
-//SetChannel ...
+// SetChannel ...
 func (s *ListenerChannel) SetChannel(seq int, dataCh chan<- cloudevents.Event) {
 	s.store[seq] = dataCh
 }
 
-//SendToListener ...
+// SendToListener ...
 func (s *ListenerChannel) SendToListener(fromRest RestAPIChannel) {
 	s.listener <- fromRest
 }

--- a/pkg/channel/types.go
+++ b/pkg/channel/types.go
@@ -14,7 +14,7 @@
 
 package channel
 
-//Status specifies status of the event
+// Status specifies status of the event
 type Status int
 
 const (
@@ -28,12 +28,12 @@ const (
 	FAILED
 )
 
-//String represent of status enum
+// String represent of status enum
 func (s Status) String() string {
 	return [...]string{"NEW", "SUCCESS", "DELETE", "FAILED"}[s]
 }
 
-//Type ... specifies type of the event
+// Type ... specifies type of the event
 type Type int
 
 const (

--- a/pkg/errorhandler/doc.go
+++ b/pkg/errorhandler/doc.go
@@ -1,2 +1,2 @@
-//Package errorhandler custom error handler for events.
+// Package errorhandler custom error handler for events.
 package errorhandler

--- a/pkg/errorhandler/errorhandler.go
+++ b/pkg/errorhandler/errorhandler.go
@@ -60,7 +60,7 @@ type SenderNotFoundError struct {
 	Desc string
 }
 
-//Error sender not found error string
+// Error sender not found error string
 func (s SenderNotFoundError) Error() string {
 	return fmt.Sprintf("sender %s not found", s.Name)
 }

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -25,27 +25,29 @@ import (
 
 // Event represents the canonical representation of a Cloud Native Event.
 // Event Json  payload is as follows,
-//{
-//	"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
-//	"type": "event.sync.sync-status.synchronization-state-change",
-//	"source": "/cluster/node/example.com/ptp/clock_realtime",
-//	"time": "2021-02-05T17:31:00Z",
-//	"data": {
-//		"version": "v1.0",
-//		"values": [{
-//			"resource": "/sync/sync-status/sync-state",
-//			"dataType": "notification",
-//			"valueType": "enumeration",
-//			"value": "ACQUIRING-SYNC"
-//			}, {
-//			"resource": "/sync/sync-status/sync-state",
-//			"dataType": "metric",
-//			"valueType": "decimal64.3",
-//			"value": 100.3
-//			}]
-//		}
-//}
-//Event request model
+//
+//	{
+//		"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
+//		"type": "event.sync.sync-status.synchronization-state-change",
+//		"source": "/cluster/node/example.com/ptp/clock_realtime",
+//		"time": "2021-02-05T17:31:00Z",
+//		"data": {
+//			"version": "v1.0",
+//			"values": [{
+//				"resource": "/sync/sync-status/sync-state",
+//				"dataType": "notification",
+//				"valueType": "enumeration",
+//				"value": "ACQUIRING-SYNC"
+//				}, {
+//				"resource": "/sync/sync-status/sync-state",
+//				"dataType": "metric",
+//				"valueType": "decimal64.3",
+//				"value": 100.3
+//				}]
+//			}
+//	}
+//
+// Event request model
 type Event struct {
 	// ID of the event; must be non-empty and unique within the scope of the producer.
 	// +required

--- a/pkg/event/event_ce.go
+++ b/pkg/event/event_ce.go
@@ -23,7 +23,7 @@ import (
 	"github.com/redhat-cne/sdk-go/pkg/pubsub"
 )
 
-//NewCloudEvent create new cloud event from cloud native events and pubsub
+// NewCloudEvent create new cloud event from cloud native events and pubsub
 func (e *Event) NewCloudEvent(ps *pubsub.PubSub) (*cloudevent.Event, error) {
 	ce := cloudevent.NewEvent(cloudevent.VersionV03)
 	ce.SetTime(e.GetTime())

--- a/pkg/event/event_data.go
+++ b/pkg/event/event_data.go
@@ -43,32 +43,33 @@ const (
 
 // Data ... cloud native events data
 // Data Json payload is as follows,
-//{
-//	"version": "v1.0",
-//	"values": [{
-//		"resource": "/sync/sync-status/sync-state",
-//		"dataType": "notification",
-//		"valueType": "enumeration",
-//		"value": "ACQUIRING-SYNC"
-//		}, {
-//		"resource": "/sync/sync-status/sync-state",
-//		"dataType": "metric",
-//		"valueType": "decimal64.3",
-//		"value": 100.3
-//		}, {
-//		"resource": "/redfish/v1/Systems",
-//		"dataType": "notification",
-//		"valueType": "redfish-event",
-//		"value": {
-// 		    "@odata.context": "/redfish/v1/$metadata#Event.Event",
-// 		    "@odata.type": "#Event.v1_3_0.Event",
-// 		    "Context": "any string is valid",
-// 		    "Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
-// 		    "Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
-// 		    "Name": "Event Array"
-//		}
-//	}]
-//}
+//
+//	{
+//		"version": "v1.0",
+//		"values": [{
+//			"resource": "/sync/sync-status/sync-state",
+//			"dataType": "notification",
+//			"valueType": "enumeration",
+//			"value": "ACQUIRING-SYNC"
+//			}, {
+//			"resource": "/sync/sync-status/sync-state",
+//			"dataType": "metric",
+//			"valueType": "decimal64.3",
+//			"value": 100.3
+//			}, {
+//			"resource": "/redfish/v1/Systems",
+//			"dataType": "notification",
+//			"valueType": "redfish-event",
+//			"value": {
+//			    "@odata.context": "/redfish/v1/$metadata#Event.Event",
+//			    "@odata.type": "#Event.v1_3_0.Event",
+//			    "Context": "any string is valid",
+//			    "Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
+//			    "Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
+//			    "Name": "Event Array"
+//			}
+//		}]
+//	}
 type Data struct {
 	Version string      `json:"version" example:"v1"`
 	Values  []DataValue `json:"values"`
@@ -76,12 +77,13 @@ type Data struct {
 
 // DataValue ...
 // DataValue Json payload is as follows,
-//{
-//	"resource": "/cluster/node/ptp",
-//	"dataType": "notification",
-//	"valueType": "enumeration",
-//	"value": "ACQUIRING-SYNC"
-//}
+//
+//	{
+//		"resource": "/cluster/node/ptp",
+//		"dataType": "notification",
+//		"valueType": "enumeration",
+//		"value": "ACQUIRING-SYNC"
+//	}
 type DataValue struct {
 	Resource  string      `json:"resource" example:"/cluster/node/clock"`
 	DataType  DataType    `json:"dataType" example:"metric"`

--- a/pkg/event/event_writer.go
+++ b/pkg/event/event_writer.go
@@ -72,7 +72,7 @@ func (e *Event) SetDataContentType(ct string) {
 	}
 }
 
-//SetData ...
+// SetData ...
 func (e *Event) SetData(data Data) {
 	nData := Data{
 		Version: data.Version,

--- a/pkg/protocol/amqp/amqp_test.go
+++ b/pkg/protocol/amqp/amqp_test.go
@@ -72,7 +72,7 @@ func CloudNativeEvents() cneevent.Event {
 	return cne
 }
 
-//CloudEvents return cloud events objects
+// CloudEvents return cloud events objects
 func CloudEvents() cloudevents.Event {
 	data := cneevent.Data{}
 	value := cneevent.DataValue{

--- a/pkg/protocol/doc.go
+++ b/pkg/protocol/doc.go
@@ -1,2 +1,2 @@
-//Package protocol  Package event provides  various protocol event.
+// Package protocol  Package event provides  various protocol event.
 package protocol

--- a/pkg/protocol/interface.go
+++ b/pkg/protocol/interface.go
@@ -21,7 +21,7 @@ import (
 	"github.com/redhat-cne/sdk-go/pkg/channel"
 )
 
-//Binder ...protocol binder base struct
+// Binder ...protocol binder base struct
 type Binder struct {
 	ID            string
 	Ctx           context.Context

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -22,12 +22,14 @@ import (
 
 // PubSub represents the canonical representation of a Cloud Native Event Publisher and Sender .
 // PubSub Json request payload is as follows,
-// {
-//  "id": "789be75d-7ac3-472e-bbbc-6d62878aad4a",
-//  "endpointUri": "http://localhost:9090/ack/event",
-//  "uriLocation":  "http://localhost:8080/api/ocloudNotifications/v1/publishers/{publisherid}",
-//  "resource":  "/east-edge-10/vdu3/o-ran-sync/sync-group/sync-status/sync-state"
-// }
+//
+//	{
+//	 "id": "789be75d-7ac3-472e-bbbc-6d62878aad4a",
+//	 "endpointUri": "http://localhost:9090/ack/event",
+//	 "uriLocation":  "http://localhost:8080/api/ocloudNotifications/v1/publishers/{publisherid}",
+//	 "resource":  "/east-edge-10/vdu3/o-ran-sync/sync-group/sync-status/sync-state"
+//	}
+//
 // PubSub request model
 type PubSub struct {
 	// ID of the pub/sub; is updated on successful creation of publisher/subscription.

--- a/pkg/types/value.go
+++ b/pkg/types/value.go
@@ -97,7 +97,8 @@ func Format(v interface{}) (string, error) {
 }
 
 // Validate v is a valid CNE attribute value, convert it to one of:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
 func Validate(v interface{}) (interface{}, error) {
 	switch v := v.(type) {
 	case bool, int32, string, []byte:
@@ -155,7 +156,9 @@ func Validate(v interface{}) (interface{}, error) {
 }
 
 // Clone v clones a CNE attribute value, which is one of the valid types:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
 // Returns the same type
 // Panics if the type is not valid
 func Clone(v interface{}) interface{} {

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -28,10 +28,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//ForeverTestTimeout ... For any test of the style:
-//   ...
-//   <- time.After(timeout):
-//      t.Errorf("Timed out")
+// ForeverTestTimeout ... For any test of the style:
+//
+//	...
+//	<- time.After(timeout):
+//	   t.Errorf("Timed out")
+//
 // The value for timeout should effectively be "forever." Obviously we don't want our tests to truly lock up forever, but 30s
 // is long enough that it is effectively forever for the things that can slow down a run on a heavily contended machine
 // (GC, seeks, etc), but not so long as to make a developer ctrl-c a test run if they do happen to break that test.
@@ -527,7 +529,7 @@ type WaitFunc func(done <-chan struct{}) <-chan struct{}
 
 // WaitFor continually checks 'fn' as driven by 'wait'.
 //
-// WaitFor gets a channel from 'wait()'', and then invokes 'fn' once for every value
+// WaitFor gets a channel from 'wait()”, and then invokes 'fn' once for every value
 // placed on the channel and once more when the channel is closed. If the channel is closed
 // and 'fn' returns false without error, WaitFor returns ErrWaitTimeout.
 //

--- a/v1/http/http.go
+++ b/v1/http/http.go
@@ -38,13 +38,13 @@ var (
 	once     sync.Once
 )
 
-//HTTP exposes http api methods
+// HTTP exposes http api methods
 type HTTP struct {
 	server  *cneHTTP.Server
 	started int32 // accessed with atomics
 }
 
-//GetHTTPInstance get event instance
+// GetHTTPInstance get event instance
 func GetHTTPInstance(serviceName string, port int, storePath string, dataIn <-chan *channel.DataChan, dataOut chan<- *channel.DataChan,
 	closeCh <-chan struct{}, onStatusReceiveOverrideFn func(e cloudevents.Event, dataChan *channel.DataChan) error, processEventFn func(e interface{}) error) (*HTTP, error) {
 	once.Do(func() {
@@ -62,7 +62,7 @@ func GetHTTPInstance(serviceName string, port int, storePath string, dataIn <-ch
 	return instance, nil
 }
 
-//Start start amqp processors
+// Start start amqp processors
 func (h *HTTP) Start(wg *sync.WaitGroup) {
 	if atomic.CompareAndSwapInt32(&h.started, 0, 1) { // protection for starting by other instances
 		log.Info("Starting http transport....")


### PR DESCRIPTION
Create senders for subscribers restored from persistent store upon starting HTTP server. This fixes the issue when events are not sent after producer pod is restarted.

This fix only changed two files:
- pkg/protocol/http/http.go
- v1/subscriber/subscriber.go

All other changes are non-functional formatting change generated by `go fmt ./...`

Signed-off-by: Jack Ding <jackding@gmail.com>