### PR TITLE
Bug OCPBUGS-8003: Cloud-event-proxy should stop sending events to the dead clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,11 @@ test:
 gha:
 	go test ./... --tags=unittests -coverprofile=cover.out
 
+fmt: ## Go fmt your code
+	hack/gofmt.sh
 
+fmt-code: ## Run go fmt against code.
+	go fmt ./...
+
+vet: ## Run go vet against code.
+	go vet ./...

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,75 +28,75 @@ These metrics describe the status of the cloud native events, publisher and subs
 
 All these metrics are prefixed with `cne_`
 
-| Name                                                  | Description                                              | Type    |
-|-------------------------------------------------------|----------------------------------------------------------|---------|
-| cne_amqp_events_received          | Metric to get number of events received  by the transport.   | Gauge |
-| cne_amqp_events_published     | Metric to get number of events published by the transport.  | Gauge   |
-| cne_amqp_connection_reset     | Metric to get number of connection resets.  | Gauge   |
-| cne_amqp_sender     | Metric to get number of sender created.  | Gauge   |
-| cne_amqp_receiver     | Metric to get number of receiver created.  | Gauge   |
-| cne_amqp_status_check_published | Metric to get number of status check published by the transport | Gauge |
+| Name                        | Description                                              | Type    |
+|-----------------------------|----------------------------------------------------------|---------|
+| cne_transport_events_received | Metric to get number of events received  by the transport.   | Gauge |
+| cne_transport_events_published       | Metric to get number of events published by the transport.  | Gauge   |
+| cne_transport_connection_reset   | Metric to get number of connection resets.  | Gauge   |
+| cne_transport_sender             | Metric to get number of sender created.  | Gauge   |
+| cne_transport_receiver           | Metric to get number of receiver created.  | Gauge   |
+| cne_transport_status_check_published | Metric to get number of status check published by the transport | Gauge |
 
-`cne_amqp_events_received` -  The number of events received by the amqp protocol, and their status by address.
+`cne_transport_events_received` -  The number of events received by the transport protocol, and their status by address.
 
 Example
-```json 
-# HELP cne_amqp_events_received Metric to get number of events received  by the transport
-# TYPE cne_amqp_events_received gauge
-cne_amqp_events_received{address="/news-service/finance",status="success"} 8
-cne_amqp_events_received{address="/news-service/sports",status="success"} 8
+``` 
+# HELP cne_transport_events_received Metric to get number of events received  by the transport
+# TYPE cne_transport_events_received gauge
+cne_transport_events_received{address="/news-service/finance",status="success"} 8
+cne_transport_events_received{address="/news-service/sports",status="success"} 8
 ```
 
-`cne_amqp_events_published` -  This metrics indicates number of events that were published via amqp , grouped by address and status.
+`cne_transport_events_published` -  This metrics indicates number of events that were published via transport , grouped by address and status.
 
 Example
-```json
-# HELP cne_amqp_events_published Metric to get number of events published by the transport
-# TYPE cne_amqp_events_published gauge
-cne_amqp_events_published{address="/news-service/finance",status="connection reset"} 1
-cne_amqp_events_published{address="/news-service/finance",status="success"} 8
-cne_amqp_events_published{address="/news-service/sports",status="connection reset"} 1
-cne_amqp_events_published{address="/news-service/sports",status="success"} 8
+```
+# HELP cne_transport_events_published Metric to get number of events published by the transport
+# TYPE cne_transport_events_published gauge
+cne_transport_events_published{address="/news-service/finance",status="connection reset"} 1
+cne_transport_events_published{address="/news-service/finance",status="success"} 8
+cne_transport_events_published{address="/news-service/sports",status="connection reset"} 1
+cne_transport_events_published{address="/news-service/sports",status="success"} 8
 ```
 
-`cne_amqp_connection_reset` -  This metrics indicates number of types amqp connection was reset
+`cne_transport_connection_reset` -  This metrics indicates number of types transport connection was reset
 
 Example
-```json
-# HELP cne_amqp_connection_reset Metric to get number of connection resets
-# TYPE cne_amqp_connection_reset gauge
-cne_amqp_connection_reset 1
+```
+# HELP cne_transport_connection_reset Metric to get number of connection resets
+# TYPE cne_transport_connection_reset gauge
+cne_transport_connection_reset 1
 ```
 
-`cne_amqp_sender` -  This metrics indicates number of amqp sender objects were created , grouped by address and status.
+`cne_transport_sender` -  This metrics indicates number of transport sender objects were created , grouped by address and status.
 
 Example
-```json
-# HELP cne_amqp_sender Metric to get number of sender active
-# TYPE cne_amqp_sender gauge
-cne_amqp_sender{address="/news-service/finance",status="active"} 1
-cne_amqp_sender{address="/news-service/sports",status="active"} 1
+```
+# HELP cne_transport_sender Metric to get number of sender active
+# TYPE cne_transport_sender gauge
+cne_transport_sender{address="/news-service/finance",status="active"} 1
+cne_transport_sender{address="/news-service/sports",status="active"} 1
 ```
 
-`cne_amqp_receiver` -  This metrics indicates number of amqp receiver objects were created, grouped by address and status.
+`cne_transport_receiver` -  This metrics indicates number of transport receiver objects were created, grouped by address and status.
 
 Example
-```json
-# HELP cne_amqp_receiver Metric to get number of receiver active
-# TYPE cne_amqp_receiver gauge
-cne_amqp_receiver{address="/news-service/finance",status="active"} 1
-cne_amqp_receiver{address="/news-service/sports",status="active"} 1
+```
+# HELP cne_transport_receiver Metric to get number of receiver active
+# TYPE cne_transport_receiver gauge
+cne_transport_receiver{address="/news-service/finance",status="active"} 1
+cne_transport_receiver{address="/news-service/sports",status="active"} 1
 ```
 
-`cne_amqp_status_check_published` -  This metrics indicates status check that were published via amqp , grouped by address and status.
+`cne_transport_status_check_published` -  This metrics indicates status check that were published via transport , grouped by address and status.
 
 Example
-```json
-# HELP cne_amqp_status_check_published  Metric to get number of status check published by the transport
-# TYPE cne_amqp_status_check_published gauge
-cne_amqp_status_check_published{address="/news-service/finance/status",status="failed"} 1
-cne_amqp_status_check_published{address="/news-service/sports/status",status="connection reset"} 1
-cne_amqp_status_check_published{address="/news-service/sports/status",status="success"} 1
+```
+# HELP cne_transport_status_check_published  Metric to get number of status check published by the transport
+# TYPE cne_transport_status_check_published gauge
+cne_transport_status_check_published{address="/news-service/finance/status",status="failed"} 1
+cne_transport_status_check_published{address="/news-service/sports/status",status="connection reset"} 1
+cne_transport_status_check_published{address="/news-service/sports/status",status="success"} 1
 ```
 
 

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -34,89 +34,89 @@ const (
 
 var (
 
-	//amqpEventReceivedCount ...  Total no of events received by the transport
-	amqpEventReceivedCount = prometheus.NewGaugeVec(
+	//transportEventReceivedCount ...  Total no of events received by the transport
+	transportEventReceivedCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_events_received",
-			Help: "Metric to get number of events received  by the transport",
+			Name: "cne_transport_events_received",
+			Help: "Metric to get number of events received by the transport",
 		}, []string{"address", "status"})
-	//amqpEventPublishedCount ...  Total no of events published by the transport
-	amqpEventPublishedCount = prometheus.NewGaugeVec(
+	//transportEventPublishedCount ...  Total no of events published by the transport
+	transportEventPublishedCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_events_published",
+			Name: "cne_transport_events_published",
 			Help: "Metric to get number of events published by the transport",
 		}, []string{"address", "status"})
 
-	//amqpConnectionResetCount ...  Total no of connection resets
-	amqpConnectionResetCount = prometheus.NewGaugeVec(
+	//transportConnectionResetCount ...  Total no of connection resets
+	transportConnectionResetCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_connection_reset",
+			Name: "cne_transport_connection_reset",
 			Help: "Metric to get number of connection resets",
 		}, []string{})
 
-	//amqpSenderCount ...  Total no of events published by the transport
-	amqpSenderCount = prometheus.NewGaugeVec(
+	//transportSenderCount ...  Total no of events published by the transport
+	transportSenderCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_sender",
+			Name: "cne_transport_sender",
 			Help: "Metric to get number of sender created",
 		}, []string{"address", "status"})
 
-	//amqpReceiverCount ...  Total no of events published by the transport
-	amqpReceiverCount = prometheus.NewGaugeVec(
+	//transportReceiverCount ...  Total no of events published by the transport
+	transportReceiverCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_receiver",
+			Name: "cne_transport_receiver",
 			Help: "Metric to get number of receiver created",
 		}, []string{"address", "status"})
 
-	//amqpStatusCheckCount ...  Total no of status check received by the transport
-	amqpStatusCheckCount = prometheus.NewGaugeVec(
+	//transportStatusCheckCount ...  Total no of status check received by the transport
+	transportStatusCheckCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cne_amqp_status_check_published",
+			Name: "cne_transport_status_check_published",
 			Help: "Metric to get number of status check published by the transport",
 		}, []string{"address", "status"})
 )
 
 // RegisterMetrics ...
 func RegisterMetrics() {
-	prometheus.MustRegister(amqpEventReceivedCount)
-	prometheus.MustRegister(amqpEventPublishedCount)
-	prometheus.MustRegister(amqpConnectionResetCount)
-	prometheus.MustRegister(amqpSenderCount)
-	prometheus.MustRegister(amqpReceiverCount)
-	prometheus.MustRegister(amqpStatusCheckCount)
+	prometheus.MustRegister(transportEventReceivedCount)
+	prometheus.MustRegister(transportEventPublishedCount)
+	prometheus.MustRegister(transportConnectionResetCount)
+	prometheus.MustRegister(transportSenderCount)
+	prometheus.MustRegister(transportReceiverCount)
+	prometheus.MustRegister(transportStatusCheckCount)
 }
 
 // UpdateTransportConnectionResetCount ...
 func UpdateTransportConnectionResetCount(val int) {
-	amqpConnectionResetCount.With(prometheus.Labels{}).Add(float64(val))
+	transportConnectionResetCount.With(prometheus.Labels{}).Add(float64(val))
 }
 
 // UpdateEventReceivedCount ...
 func UpdateEventReceivedCount(address string, status MetricStatus, val int) {
-	amqpEventReceivedCount.With(
+	transportEventReceivedCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
 
 // UpdateEventCreatedCount ...
 func UpdateEventCreatedCount(address string, status MetricStatus, val int) {
-	amqpEventPublishedCount.With(
+	transportEventPublishedCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
 
 // UpdateStatusCheckCount ...
 func UpdateStatusCheckCount(address string, status MetricStatus, val int) {
-	amqpEventPublishedCount.With(
+	transportEventPublishedCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
 
 // UpdateSenderCreatedCount ...
 func UpdateSenderCreatedCount(address string, status MetricStatus, val int) {
-	amqpSenderCount.With(
+	transportSenderCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }
 
 // UpdateReceiverCreatedCount ...
 func UpdateReceiverCreatedCount(address string, status MetricStatus, val int) {
-	amqpReceiverCount.With(
+	transportReceiverCount.With(
 		prometheus.Labels{"address": address, "status": string(status)}).Add(float64(val))
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -27,6 +27,16 @@ type PubSubStore struct {
 	Store map[string]*pubsub.PubSub
 }
 
+// Get ...
+func (ps *PubSubStore) Get(subID string) pubsub.PubSub {
+	ps.Lock()
+	defer ps.Unlock()
+	if s, ok := ps.Store[subID]; ok {
+		return *s
+	}
+	return pubsub.PubSub{}
+}
+
 // Set is a wrapper for setting the value of a key in the underlying map
 func (ps *PubSubStore) Set(key string, val pubsub.PubSub) {
 	ps.Lock()

--- a/pkg/store/subscriber/subscriber.go
+++ b/pkg/store/subscriber/subscriber.go
@@ -22,6 +22,16 @@ func (ss *Store) Set(clientID uuid.UUID, val subscriber.Subscriber) {
 	ss.Store[clientID] = &val
 }
 
+// Get is a wrapper for Getting the value of a key in the underlying map
+func (ss *Store) Get(clientID uuid.UUID) (subscriber.Subscriber, bool) {
+	ss.Lock()
+	defer ss.Unlock()
+	if s, ok := ss.Store[clientID]; ok {
+		return *s, true
+	}
+	return subscriber.Subscriber{}, false
+}
+
 // Delete ... delete from store
 func (ss *Store) Delete(clientID uuid.UUID) {
 	ss.Lock()

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -58,6 +58,11 @@ type Subscriber struct {
 	failedCount int
 }
 
+// Get ... get pubsub
+func (s *Subscriber) Get(subID string) pubsub.PubSub {
+	return s.SubStore.Get(subID)
+}
+
 // IncFailCount ...
 func (s *Subscriber) IncFailCount() {
 	s.failedCount++

--- a/v1/subscriber/subscriber_test.go
+++ b/v1/subscriber/subscriber_test.go
@@ -156,6 +156,64 @@ func TestAPI_HasSubscription(t *testing.T) {
 	assert.Equal(t, *s.SubStore.Store[fs.ID], fs)
 }
 
+func Test_Concurrency(t *testing.T) {
+	defer clean()
+	s, e := globalInstance.CreateSubscription(clientID, subscriberWithOneEventCheck)
+	assert.Nil(t, e)
+	assert.NotEmpty(t, s.ClientID)
+	assert.NotNil(t, s.SubStore.Store)
+	assert.Equal(t, 1, len(s.SubStore.Store))
+	s, e = globalInstance.CreateSubscription(clientID, subscriberWithManyEventCheck)
+	assert.Nil(t, e)
+	assert.NotEmpty(t, s.ClientID)
+	assert.NotNil(t, s.SubStore.Store)
+	assert.Equal(t, 2, len(s.SubStore.Store))
+	assert.Equal(t, s.SubStore.Store[subscriptionOne.ID].URILocation, subscriptionOne.URILocation)
+	assert.Equal(t, s.SubStore.Store[subscriptionOne.ID].Resource, subscriptionOne.Resource)
+	assert.Equal(t, s.SubStore.Store[subscriptionOne.ID].EndPointURI, subscriptionOne.EndPointURI)
+	b, e := globalInstance.GetSubscriptionsFromFile(clientID)
+	assert.Nil(t, e)
+	assert.NotNil(t, b)
+	assert.NotEmpty(t, b)
+	var subscriptionClient subscriber.Subscriber
+	e = json.Unmarshal(b, &subscriptionClient)
+	assert.NotNil(t, subscriptionClient)
+	assert.Nil(t, e)
+	assert.NotEmpty(t, s, subscriptionClient)
+	assert.Equal(t, *s, subscriptionClient)
+	assert.NotNil(t, subscriptionClient.SubStore)
+	assert.Equal(t, len(s.SubStore.Store), len(subscriptionClient.SubStore.Store))
+	//assert.NotEmpty(t, subscriber[0].SubStore.)
+	assert.Equal(t, subscriptionOne, subscriptionClient.SubStore.Store[subscriptionOne.ID])
+
+	var wg sync.WaitGroup
+	for i := 0; i <= 10; i++ {
+		wg.Add(1)
+		go func(w *sync.WaitGroup) {
+			defer w.Done()
+			cID := uuid.New()
+			s, e = globalInstance.CreateSubscription(cID, subscriberWithManyEventCheck)
+			assert.Nil(t, e)
+			assert.NotEmpty(t, s.ClientID)
+			assert.NotNil(t, globalInstance.GetSubscriptions(cID))
+			store, ok := globalInstance.SubscriberStore.Get(cID)
+			assert.True(t, ok)
+			assert.Equal(t, 2, len(store.SubStore.Store))
+
+			assert.Equal(t, store.SubStore.Store[subscriptionOne.ID].URILocation, subscriptionOne.URILocation)
+			assert.Equal(t, store.SubStore.Store[subscriptionOne.ID].Resource, subscriptionOne.Resource)
+			assert.Equal(t, store.SubStore.Store[subscriptionOne.ID].EndPointURI, subscriptionOne.EndPointURI)
+			_, T := globalInstance.HasClient(subscriptionClient.ClientID)
+			assert.True(t, true, T)
+			_ = globalInstance.UpdateStatus(subscriptionClient.ClientID, subscriber.InActive)
+			if s, ok := globalInstance.SubscriberStore.Get(subscriptionClient.ClientID); ok {
+				assert.NotEmpty(t, s.EndPointURI)
+			}
+		}(&wg)
+	}
+	wg.Wait()
+}
+
 func clean() {
 	_ = globalInstance.DeleteAllSubscriptions(clientID)
 }


### PR DESCRIPTION
This PR fixes
1. Subscribers not deleted when a client goes away
2. subscriber and event response was not available  via cloud event send operation which was causing error reporting in logs
3. updated  metrics by renaming amq to transport