### PR TITLE
CNF-13067: O-RAN V3 Rest Api: Status Notification

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,10 +21,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// REST API versions
 const (
-	V1 = "1.0"
-	V2 = "2.0"
+	RestAPIV1 = "1.0"
+	RestAPIV2 = "2.0"
 )
 
 func getMajorVersion(version string) (int, error) {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -23,6 +23,8 @@ import (
 	"github.com/redhat-cne/sdk-go/pkg/types"
 )
 
+const APISchemaVersion = "1.0"
+
 // Event represents the canonical representation of a Cloud Native Event.
 // Event Json  payload is as follows,
 //

--- a/pkg/event/event_ce.go
+++ b/pkg/event/event_ce.go
@@ -39,6 +39,20 @@ func (e *Event) NewCloudEvent(ps *pubsub.PubSub) (*cloudevent.Event, error) {
 	return &ce, nil
 }
 
+// NewCloudEvent create new cloud event from cloud native events and pubsub
+func (e *Event) NewCloudEventV2(ps *pubsub.PubSub) (*cloudevent.Event, error) {
+	ce := cloudevent.NewEvent(cloudevent.VersionV1)
+	ce.SetTime(e.GetTime())
+	ce.SetType(e.Type)
+	ce.SetSource(ps.Resource) // bus address
+	ce.SetSpecVersion(cloudevent.VersionV1)
+	ce.SetID(uuid.New().String())
+	if err := ce.SetData("", e.GetData()); err != nil {
+		return nil, err
+	}
+	return &ce, nil
+}
+
 // GetCloudNativeEvents  get event data from cloud events object if its valid else return error
 func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	if ce.Data() == nil {

--- a/pkg/event/ptp/resource.go
+++ b/pkg/event/ptp/resource.go
@@ -18,27 +18,34 @@ package ptp
 type EventResource string
 
 const (
+	// O-RAN 7.2.3.6
 	// GnssSyncStatus notification is signalled from equipment at state change
 	GnssSyncStatus EventResource = "/sync/gnss-status/gnss-sync-status"
 
+	// O-RAN 7.2.3.8
 	// OsClockSyncState State of node OS clock synchronization is notified at state change
 	OsClockSyncState EventResource = "/sync/sync-status/os-clock-sync-state"
 
+	// O-RAN 7.2.3.10
 	// PtpClockClass notification is generated when the clock-class changes.
-	PtpClockClass EventResource = "/sync/ptp-status/ptp-clock-class-change"
+	PtpClockClass EventResource = "/sync/ptp-status/clock-class"
 
+	// O-RAN 7.2.3.3
 	// PtpLockState notification is signalled from equipment at state change
 	PtpLockState EventResource = "/sync/ptp-status/lock-state"
 
+	// O-RAN 7.2.3.11
 	// SynceClockQuality notification is generated when the clock-quality changes.
 	SynceClockQuality EventResource = "/sync/synce-status/clock-quality"
 
+	// O-RAN 7.2.3.9
 	// SynceLockState Notification used to inform about synce synchronization state change
 	SynceLockState EventResource = "/sync/synce-status/lock-state"
 
 	// SynceLockStateExtended notification is signalled from equipment at state change, enhanced information
 	SynceLockStateExtended EventResource = "/sync/synce-status/lock-state-extended"
 
-	// SyncStatusState State of equipment synchronization is notified at state change
+	// O-RAN 7.2.3.1
+	// SyncStatusState is the overall synchronization health of the node, including the OS System Clock
 	SyncStatusState EventResource = "/sync/sync-status/sync-state"
 )

--- a/pkg/event/ptp/syncstate.go
+++ b/pkg/event/ptp/syncstate.go
@@ -30,6 +30,18 @@ const (
 	// BOOTING ...
 	BOOTING SyncState = "BOOTING"
 
+	// FAILURE_MULTIPATH is GNSS Sync Failure - Multipath condition detected
+	FAILURE_MULTIPATH SyncState = "FAILURE-MULTIPATH"
+
+	// FAILURE_NOFIX is GNSS Sync Failure - Unknown
+	FAILURE_NOFIX SyncState = "FAILURE-NOFIX"
+
+	// FAILURE_LOW_SNR is GNSS Sync Failure - Low SNR condition detected
+	FAILURE_LOW_SNR SyncState = "FAILURE-LOW-SNR"
+
+	// FAILURE_PLL is GNSS Sync Failure - PLL is not functioning
+	FAILURE_PLL SyncState = "FAILURE-PLL"
+
 	// FREERUN ...
 	FREERUN SyncState = "FREERUN"
 

--- a/pkg/event/ptp/types.go
+++ b/pkg/event/ptp/types.go
@@ -18,27 +18,34 @@ package ptp
 type EventType string
 
 const (
+	// O-RAN 7.2.3.6
 	// GnssStateChange is Notification used to inform about gnss synchronization state change
 	GnssStateChange EventType = "event.sync.gnss-status.gnss-state-change"
 
+	// O-RAN 7.2.3.8
 	// OsClockSyncStateChange is the object contains information related to a notification
 	OsClockSyncStateChange EventType = "event.sync.sync-status.os-clock-sync-state-change"
 
+	// O-RAN 7.2.3.10
 	// PtpClockClassChange is Notification used to inform about ptp clock class changes.
 	PtpClockClassChange EventType = "event.sync.ptp-status.ptp-clock-class-change"
 
+	// O-RAN 7.2.3.3
 	// PtpStateChange is Notification used to inform about ptp synchronization state change
 	PtpStateChange EventType = "event.sync.ptp-status.ptp-state-change"
 
+	// O-RAN 7.2.3.11
 	// SynceClockQualityChange is Notification used to inform about changes in the clock quality of the primary SyncE signal advertised in ESMC packets
-	SynceClockQualityChange EventType = "event.sync.synce-status.sync-clock-quality-change"
+	SynceClockQualityChange EventType = "event.sync.synce-status.synce-clock-quality-change"
 
+	// O-RAN 7.2.3.9
 	// SynceStateChange is Notification used to inform about synce synchronization state change
-	SynceStateChange EventType = "event.sync.sync-status.synce-state-change"
+	SynceStateChange EventType = "event.sync.synce-status.synce-state-change"
 
 	// SynceStateChangeExtended is Notification used to inform about synce synchronization state change, enhanced state information
 	SynceStateChangeExtended EventType = "event.sync.synce-status.synce-state-change-extended"
 
-	// SyncStateChange is Notification used to inform about synchronization state change
+	// O-RAN 7.2.3.1
+	// SyncStateChange is Notification used to inform about the overall synchronization state change
 	SyncStateChange EventType = "event.sync.sync-status.synchronization-state-change"
 )

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -52,7 +52,7 @@ func (ps *PubSub) String() string {
 	b := strings.Builder{}
 	b.WriteString("  EndpointUri: " + ps.GetEndpointURI() + "\n")
 	b.WriteString("  UriLocation: " + ps.GetURILocation() + "\n")
-	b.WriteString("  ID: " + ps.GetID() + "\n")
+	b.WriteString("  SubscriptionId: " + ps.GetID() + "\n")
 	b.WriteString("  Resource: " + ps.GetResource() + "\n")
 	return b.String()
 }

--- a/pkg/pubsub/pubsub_unmarshal.go
+++ b/pkg/pubsub/pubsub_unmarshal.go
@@ -73,7 +73,7 @@ func readJSONFromIterator(out *PubSub, iterator *jsoniter.Iterator) error {
 			uriLocation = iterator.ReadString()
 		case "ResourceAddress":
 			resource = iterator.ReadString()
-			version = common.V2
+			version = common.RestAPIV2
 		case "id":
 			id = iterator.ReadString()
 		case "endpointUri":
@@ -82,7 +82,7 @@ func readJSONFromIterator(out *PubSub, iterator *jsoniter.Iterator) error {
 			uriLocation = iterator.ReadString()
 		case "resource":
 			resource = iterator.ReadString()
-			version = common.V1
+			version = common.RestAPIV1
 		default:
 			iterator.Skip()
 		}

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -49,7 +49,7 @@ type Subscriber struct {
 	SubStore *store.PubSubStore `json:"subStore" omit:"empty"`
 	// EndPointURI - A URI describing the subscriber link .
 	// +required
-	EndPointURI *types.URI `json:"endPointURI" omit:"empty"`
+	EndPointURI *types.URI `json:"EndpointUri" omit:"empty"`
 	// Status ...
 	Status Status `json:"status" omit:"empty"`
 	// Action ...
@@ -84,8 +84,8 @@ func (s *Subscriber) FailedCount() int {
 // String returns a pretty-printed representation of the Event.
 func (s *Subscriber) String() string {
 	b := strings.Builder{}
-	b.WriteString("  EndPointURI: " + s.GetEndPointURI() + "\n")
-	b.WriteString("  ID: " + s.GetClientID().String() + "\n")
+	b.WriteString("  EndpointUri: " + s.GetEndPointURI() + "\n")
+	b.WriteString("  clientID: " + s.GetClientID().String() + "\n")
 	b.WriteString("  sub :{")
 	if s.SubStore != nil {
 		for _, v := range s.SubStore.Store {

--- a/pkg/subscriber/subscriber_writer.go
+++ b/pkg/subscriber/subscriber_writer.go
@@ -42,12 +42,6 @@ func (s *Subscriber) SetStatus(status Status) {
 // AddSubscription ...
 func (s *Subscriber) AddSubscription(subs ...pubsub.PubSub) {
 	for _, ss := range subs {
-		newS := &pubsub.PubSub{
-			ID:          ss.GetID(),
-			EndPointURI: nil,
-			URILocation: nil,
-			Resource:    ss.Resource,
-		}
-		s.SubStore.Store[ss.GetID()] = newS
+		s.SubStore.Store[ss.GetID()] = &ss
 	}
 }

--- a/v1/subscriber/subscriber_test.go
+++ b/v1/subscriber/subscriber_test.go
@@ -134,7 +134,7 @@ func TestAPI_DeleteAllSubscriptions(t *testing.T) {
 	b, e := globalInstance.GetSubscriptionsFromFile(clientID)
 	assert.Nil(t, e)
 	assert.Len(t, b, 0)
-	assert.Len(t, globalInstance.GetSubscriptions(clientID), 0)
+	assert.Len(t, globalInstance.GetSubscriptionsFromClientID(clientID), 0)
 }
 
 func TestAPI_DeleteSubscription(t *testing.T) {
@@ -145,7 +145,7 @@ func TestAPI_DeleteSubscription(t *testing.T) {
 	assert.NotNil(t, s.SubStore.Store)
 	e = globalInstance.DeleteSubscription(clientID, subscriptionOne.ID)
 	assert.Nil(t, e)
-	delSub := globalInstance.GetSubscription(clientID, subscriptionOne.ID)
+	delSub, _ := globalInstance.GetSubscription(clientID, subscriptionOne.ID)
 	assert.Equal(t, delSub, pubsub.PubSub{})
 }
 
@@ -197,7 +197,7 @@ func Test_Concurrency(t *testing.T) {
 			s, e = globalInstance.CreateSubscription(cID, subscriberWithManyEventCheck)
 			assert.Nil(t, e)
 			assert.NotEmpty(t, s.ClientID)
-			assert.NotNil(t, globalInstance.GetSubscriptions(cID))
+			assert.NotNil(t, globalInstance.GetSubscriptionsFromClientID(cID))
 			store, ok := globalInstance.SubscriberStore.Get(cID)
 			assert.True(t, ok)
 			assert.Equal(t, 2, len(store.SubStore.Store))


### PR DESCRIPTION
- Upgrade Cloud Event spec version to V1 from V03
- Update definitions of Synchronization Event Specifications
- Remove local store for pubsub: sub.json. Now access to sub info only through SubscriberAPI/store.
- Not setting subject in Cloud Event according to O-RAN spec
- Not setting datacontenttype in Cloud Event according to O-RAN spec
- Add error handling in subscriber ReloadStore

More details in doc https://docs.google.com/document/d/1aIgGWhFDDz9aI7mIZm_nlkb99UrV7hv5gS5m_XShCt4/edit