### PR TITLE
Add ResetFailCount to subscriberAPI

### DIFF
--- a/pkg/protocol/http/http.go
+++ b/pkg/protocol/http/http.go
@@ -587,6 +587,7 @@ func (h *Server) SendTo(wg *sync.WaitGroup, clientID uuid.UUID, clientAddress, r
 				}
 				log.Errorf("connection lost addressing %s", clientAddress)
 			} else {
+				h.subscriberAPI.ResetFailCount(clientID)
 				localmetrics.UpdateEventCreatedCount(resourceAddress, localmetrics.SUCCESS, 1)
 				h.DataOut <- &channel.DataChan{
 					Address: resourceAddress,

--- a/v1/subscriber/subscriber.go
+++ b/v1/subscriber/subscriber.go
@@ -395,6 +395,14 @@ func (p *API) IncFailCountToFail(clientID uuid.UUID) bool {
 	return false
 }
 
+// ResetFailCount ..reset fail count
+func (p *API) ResetFailCount(clientID uuid.UUID) {
+	if subStore, ok := p.SubscriberStore.Get(clientID); ok {
+		subStore.ResetFailCount()
+		p.SubscriberStore.Set(clientID, subStore)
+	}
+}
+
 // FailCountThreshold .. get threshold
 func (p *API) FailCountThreshold() int {
 	return subscriber.SetConnectionToFailAfter


### PR DESCRIPTION
reset fail count when a event is successfully delivered.
