### PR TITLE
OCPBUGS-44954: PTP operator Event Notification API breaking change within 4.16 release

### DIFF
--- a/pkg/event/ptp/resource.go
+++ b/pkg/event/ptp/resource.go
@@ -30,6 +30,10 @@ const (
 	// PtpClockClass notification is generated when the clock-class changes.
 	PtpClockClass EventResource = "/sync/ptp-status/clock-class"
 
+	// Support V1
+	// PtpClockClassV1 notification is generated when the clock-class changes for v1.
+	PtpClockClassV1 EventResource = "/sync/ptp-status/ptp-clock-class-change"
+
 	// O-RAN 7.2.3.3
 	// PtpLockState notification is signalled from equipment at state change
 	PtpLockState EventResource = "/sync/ptp-status/lock-state"


### PR DESCRIPTION
Fix Backward Compatibility for PTP Clock-Class Event Subscription (PR 1 of 2)

This is the first of two pull requests to address a backward compatibility issue. The second PR will be in the cloud-event-proxy repository.

The problem arises because the V1 version of PTP events subscribed to the resource address **/sync/ptp-status/ptp-clock-class-change**, which was  updated to  **/sync/ptp-status/clock-class**  in V2 as per O-RAN spec.
 As a result, older versions referencing **/sync/ptp-status/ptp-clock-class-change** failed to subscribe to clock-class events.

This PR resolves the issue by introducing a new enum type, **PtpClockClassV1**, which refers to the older event resource. 
The solution ensures backward compatibility for V1 while adhering to the O-RAN 7.2.3.10 specification for the PtpClockClass notification.

Key Changes:

    Added **PtpClockClassV1** to support the older **/sync/ptp-status/ptp-clock-class-change** resource for V1 compatibility.
    Retained the **PtpClockClass** resource for the updated **/sync/ptp-status/clock-class** to align with the O-RAN specification.

Updated Definitions:

// O-RAN 7.2.3.10
// PtpClockClass notification is generated when the clock-class changes.
PtpClockClass EventResource = "/sync/ptp-status/clock-class"

// Support V1
// PtpClockClassV1 notification is generated when the clock-class changes for V1.
PtpClockClassV1 EventResource = "/sync/ptp-status/ptp-clock-class-change"

This change ensures that both V1 and the current versions of PTP events can correctly subscribe to clock-class notifications without breaking functionality for older versions.
