### PR TITLE
v1: Return 400 from getCurrentState for unavailable event data

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,7 @@ output:
 linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 30
+    min-complexity: 34
   govet:
     enable:
       - shadow


### PR DESCRIPTION
When event data is not available (e.g., event socket not ready), the getCurrentState function returned a FREERUN state with a ResourceAddress of "event-not-found". This incorrect state could cause a cell site outage.

This change modifies the function to return a 400 status in this scenario, preventing the potential outage.

Also added similar detection and handling for "ptp-not-set".